### PR TITLE
Only enable NewRelic agent if license key set

### DIFF
--- a/target/newrelic.js
+++ b/target/newrelic.js
@@ -13,6 +13,7 @@ exports.config = {
    * Your New Relic license key.
    */
   license_key : process.env.NEW_RELIC_LICENSE_KEY,
+  agent_enabled: (process.env.NEW_RELIC_LICENSE_KEY != null),
   logging : {
     /**
      * Level at which to log. 'trace' is most useful to New Relic when diagnosing


### PR DESCRIPTION
This fixes the second issue reported in https://github.com/motepair/motepair-server/issues/3
